### PR TITLE
Improve mobile UI: header, MAGI panel, tables, cycles page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -80,6 +80,43 @@ body {
   text-align: right;
 }
 
+/* ── Header mobile ──────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .header { padding: 0 12px; }
+  .header-inner {
+    height: auto;
+    flex-wrap: wrap;
+    gap: 0;
+    padding: 8px 0 0;
+  }
+  /* Row 1: logo (left) + countdown + dot (right) */
+  .logo { flex: 1; }
+  .next-cycle-wrap { margin-left: 0; }
+  .next-cycle-label { display: none; }
+  .next-cycle-timer { font-size: 13px; }
+  /* Row 2: nav full width */
+  .nav {
+    order: 3;
+    width: 100%;
+    gap: 0;
+    border-top: 1px solid var(--border);
+    margin-top: 8px;
+    padding: 4px 0;
+  }
+  .nav-link {
+    flex: 1;
+    text-align: center;
+    padding: 8px 4px;
+    font-size: 12px;
+    border-radius: 0;
+  }
+  .nav-link.active {
+    border-bottom: 2px solid var(--blue);
+    background: none;
+    color: var(--text);
+  }
+}
+
 /* Live indicator */
 .live-dot {
   width: 8px; height: 8px;
@@ -217,6 +254,7 @@ body {
 }
 
 /* ── Table ────────────────────────────────────────────────────── */
+.table-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .table {
   width: 100%;
   border-collapse: collapse;
@@ -472,6 +510,61 @@ body {
   content: '● ';
 }
 
+/* ── MAGI mobile: hide side columns, center only ─────────────── */
+@media (max-width: 600px) {
+  .magi-side { display: none; }
+}
+
+/* Mobile decision overlay — top-left empty area of SVG */
+.magi-lbl-mobile-decision {
+  display: none;
+  top: 2%; left: 1%;
+  width: 26%; height: 46%;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 6;
+}
+.magi-lbl-mobile-decision .magi-signal {
+  font-size: 13px;
+  letter-spacing: .04em;
+  margin-top: 0;
+}
+@media (max-width: 600px) {
+  .magi-lbl-mobile-decision { display: flex; }
+}
+
+/* Mobile status overlay — top-right empty area of SVG */
+.magi-lbl-mobile-status {
+  display: none;
+  top: 2%; right: 1%;
+  width: 26%; height: 46%;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  z-index: 6;
+}
+@media (max-width: 600px) {
+  .magi-lbl-mobile-status { display: flex; }
+}
+
+/* PC版クラスをそのまま使い、サイズだけ縮小 */
+.magi-lbl-mobile-status .magi-status-badge {
+  font-size: 8px;
+  padding: 2px 5px;
+  border-width: 1px;
+  margin-top: 0;
+  letter-spacing: .03em;
+}
+.magi-lbl-mobile-status .magi-round-label {
+  font-size: 7px;
+}
+
+/* cycle-active: 審議中表示・結果非表示 */
+#magi-mobile-status.cycle-active .magi-running-badge { display: block; }
+#magi-mobile-status.cycle-active .magi-result-badge  { display: none; }
+
 /* ── Utilities ────────────────────────────────────────────────── */
 .mono    { font-family: "SFMono-Regular", Consolas, monospace; }
 .small   { font-size: 12px; }
@@ -480,51 +573,88 @@ body {
 .text-red   { color: var(--red); }
 
 /* ── Cycles page ──────────────────────────────────────────────── */
-.cycle-block { margin-bottom: 10px; padding: 14px 18px; }
+.cycles-summary-card { margin-bottom: 10px; padding: 12px 16px; }
 
+.cycle-block {
+  margin-bottom: 8px;
+  padding: 12px 14px;
+}
+
+/* Header: left=badges, right=meta+toggle */
 .cycle-header {
   display: flex;
+  justify-content: space-between;
   align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
+  gap: 8px;
   cursor: pointer;
   user-select: none;
+  -webkit-tap-highlight-color: transparent;
 }
-.cycle-id   { font-size: 12px; min-width: 36px; }
-.cycle-ts   { min-width: 160px; }
-.cycle-coin { font-weight: 700; font-size: 13px; }
-.cycle-action-label { font-size: 11px; }
-.cycle-skip-reason  { font-size: 11px; color: var(--muted); font-style: italic; flex: 1; }
+.cycle-header-main {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  flex: 1;
+  min-width: 0;
+}
+.cycle-header-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+.cycle-coin  { font-weight: 700; font-size: 13px; }
+.cycle-arrow { font-size: 11px; }
+.cycle-id    { font-size: 11px; }
+.cycle-ts    { font-size: 11px; }
+
+@media (max-width: 480px) {
+  .cycle-ts { display: none; }
+}
 
 .cycle-toggle {
-  margin-left: auto;
   background: none;
   border: none;
   color: var(--muted);
   cursor: pointer;
   font-size: 14px;
-  padding: 2px 6px;
+  padding: 4px 6px;
   border-radius: 4px;
+  line-height: 1;
+  flex-shrink: 0;
 }
 .cycle-toggle:hover { background: var(--surface2); color: var(--text); }
 
-.cycle-body { margin-top: 14px; border-top: 1px solid var(--border); padding-top: 14px; }
+.cycle-skip-reason {
+  font-size: 11px;
+  color: var(--muted);
+  font-style: italic;
+  padding: 4px 0 0;
+}
 
-.cycle-section { margin-bottom: 18px; }
+.cycle-body {
+  margin-top: 12px;
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+
+.cycle-section { margin-bottom: 16px; }
 .cycle-section:last-child { margin-bottom: 0; }
 .cycle-section-title {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 11px;
+  gap: 6px;
+  font-size: 10px;
   text-transform: uppercase;
   letter-spacing: .08em;
   color: var(--muted);
-  margin-bottom: 10px;
+  margin-bottom: 8px;
 }
 
 /* Vote rounds */
-.vote-round { margin-bottom: 12px; }
+.vote-round { margin-bottom: 10px; }
 .vote-round-label {
   font-size: 10px;
   text-transform: uppercase;
@@ -535,28 +665,35 @@ body {
 .vote-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
+  gap: 6px;
 }
-@media (max-width: 700px) { .vote-grid { grid-template-columns: 1fr; } }
+@media (max-width: 600px) { .vote-grid { grid-template-columns: 1fr; gap: 6px; } }
 
 .vote-card {
   background: var(--surface2);
   border: 1px solid var(--border);
   border-radius: 6px;
-  padding: 10px 12px;
+  padding: 8px 10px;
 }
 .vote-card-long  { border-left: 3px solid var(--green); }
 .vote-card-short { border-left: 3px solid var(--red); }
 .vote-card-hold  { border-left: 3px solid var(--yellow); }
 .vote-card-exit  { border-left: 3px solid var(--red); }
 
-.vote-agent { font-weight: 700; font-size: 12px; margin-bottom: 4px; text-transform: capitalize; }
-.vote-decision { margin-bottom: 4px; }
+.vote-card-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+.vote-agent { font-weight: 700; font-size: 12px; text-transform: capitalize; }
+.vote-ts    { font-size: 10px; color: var(--muted); margin-left: auto; }
+
 .vote-reasoning {
   font-size: 12px;
   color: var(--muted);
   line-height: 1.5;
-  margin-top: 6px;
   max-height: 120px;
   overflow-y: auto;
   white-space: pre-wrap;
@@ -569,20 +706,26 @@ body {
   color: var(--text);
   background: var(--surface2);
   border-radius: 6px;
-  padding: 12px 14px;
-  max-height: 260px;
+  padding: 10px 12px;
+  max-height: 240px;
   overflow-y: auto;
 }
 
-/* Trade detail inline */
-.trade-detail-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
+/* Trade key-value grid */
+.trade-kv {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 14px;
   font-size: 13px;
-  margin-top: 4px;
+  margin-top: 6px;
 }
+.trade-kv dt {
+  color: var(--muted);
+  font-size: 11px;
+  align-self: center;
+  white-space: nowrap;
+}
+.trade-kv dd { align-self: center; }
 
 /* Reflection dropdown */
 .reflection-details {
@@ -592,7 +735,7 @@ body {
   overflow: hidden;
 }
 .reflection-summary {
-  padding: 8px 14px;
+  padding: 8px 12px;
   font-size: 12px;
   font-weight: 600;
   color: var(--blue);
@@ -603,7 +746,7 @@ body {
 .reflection-summary::-webkit-details-marker { display: none; }
 .reflection-summary:hover { background: var(--surface); }
 .reflection-body {
-  padding: 12px 14px;
+  padding: 10px 12px;
   font-size: 12px;
   line-height: 1.7;
   color: var(--text);

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CC Visual Trade</title>
-  <link rel="stylesheet" href="/static/style.css?v=4">
+  <link rel="stylesheet" href="/static/style.css?v=12">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 </head>
 <body>

--- a/templates/cycles.html
+++ b/templates/cycles.html
@@ -2,7 +2,7 @@
 {% set page = "cycles" %}
 
 {% block content %}
-<div class="card" style="margin-bottom: var(--gap);">
+<div class="card cycles-summary-card">
   <div class="card-label">Cycle History — {{ cycles | length }} cycles</div>
   {% if not cycles %}
     <div class="muted" style="padding:2rem;text-align:center;">No cycles yet.</div>
@@ -12,25 +12,35 @@
 {% for c in cycles %}
 <div class="cycle-block card" id="cycle-{{ c.id }}">
 
-  <!-- Header row -->
-  <div class="cycle-header">
-    <span class="cycle-id muted mono">#{{ c.id }}</span>
-    <span class="cycle-ts mono small muted">{{ c.timestamp }}</span>
-    <span class="cycle-coin">{{ c.coin }}</span>
-    {% if c.decision %}
-      <span class="badge badge-{{ c.decision | lower }}">{{ c.decision }}</span>
-    {% else %}
-      <span class="badge badge-interrupted">—</span>
-    {% endif %}
-    {% if c.action %}
-      <span class="cycle-action-label muted small">→</span>
-      <span class="badge-status badge-status-{{ c.action }}">{{ c.action }}</span>
-    {% endif %}
-    {% if c.skip_reason %}
-      <span class="cycle-skip-reason muted small">{{ c.skip_reason }}</span>
-    {% endif %}
-    <button class="cycle-toggle" onclick="toggleCycle('cycle-{{ c.id }}')" title="Expand / Collapse">▾</button>
+  <!-- Header: clickable, collapses on mobile -->
+  <div class="cycle-header" onclick="toggleCycle('cycle-{{ c.id }}')">
+
+    <!-- Left: coin + badges -->
+    <div class="cycle-header-main">
+      <span class="cycle-coin">{{ c.coin }}</span>
+      {% if c.decision %}
+        <span class="badge badge-{{ c.decision | lower }}">{{ c.decision }}</span>
+      {% else %}
+        <span class="badge badge-interrupted">—</span>
+      {% endif %}
+      {% if c.action %}
+        <span class="cycle-arrow muted">→</span>
+        <span class="badge-status badge-status-{{ c.action }}">{{ c.action }}</span>
+      {% endif %}
+    </div>
+
+    <!-- Right: id + timestamp + toggle -->
+    <div class="cycle-header-meta">
+      <span class="cycle-id muted mono">#{{ c.id }}</span>
+      <span class="cycle-ts mono muted">{{ c.timestamp }}</span>
+      <button class="cycle-toggle" id="btn-cycle-{{ c.id }}" title="Expand / Collapse">▾</button>
+    </div>
+
   </div>
+
+  {% if c.skip_reason %}
+  <div class="cycle-skip-reason">{{ c.skip_reason }}</div>
+  {% endif %}
 
   <!-- Expandable body -->
   <div class="cycle-body" id="body-cycle-{{ c.id }}">
@@ -41,13 +51,17 @@
       <div class="cycle-section-title">MAGI Votes</div>
       {% for round_num, votes in c.rounds.items() %}
       <div class="vote-round">
-        <span class="vote-round-label">Round {{ round_num + 1 }}</span>
+        {% if c.rounds | length > 1 %}
+        <div class="vote-round-label">Round {{ round_num + 1 }}</div>
+        {% endif %}
         <div class="vote-grid">
           {% for v in votes %}
           <div class="vote-card vote-card-{{ v.decision | lower }}">
-            <div class="vote-agent">{{ v.agent | capitalize }}</div>
-            <div class="vote-decision badge badge-{{ v.decision | lower }}">{{ v.decision }}</div>
-            <div class="vote-ts mono" style="font-size:10px;color:var(--muted)">{{ v.timestamp }}</div>
+            <div class="vote-card-header">
+              <span class="vote-agent">{{ v.agent | capitalize }}</span>
+              <span class="badge badge-{{ v.decision | lower }}">{{ v.decision }}</span>
+              <span class="vote-ts mono">{{ v.timestamp }}</span>
+            </div>
             {% if v.reasoning %}
             <div class="vote-reasoning">{{ v.reasoning }}</div>
             {% endif %}
@@ -81,17 +95,15 @@
           <span class="muted small">({{ "WIN" if t.pnl_usd > 0 else ("LOSS" if t.pnl_usd < 0 else "BE") }})</span>
         {% endif %}
       </div>
-      <div class="trade-detail-row">
-        <span class="label">Entry</span><span class="mono">${{ "{:,.2f}".format(t.entry_price) }}</span>
-        <span class="label" style="margin-left:20px;">Exit</span>
-        <span class="mono">{% if t.exit_price %}${{ "{:,.2f}".format(t.exit_price) }}{% else %}—{% endif %}</span>
-        <span class="label" style="margin-left:20px;">Time</span><span class="mono small">{{ t.entry_time }}</span>
+      <dl class="trade-kv">
+        <dt>Entry</dt><dd class="mono">${{ "{:,.2f}".format(t.entry_price) }}</dd>
+        <dt>Exit</dt><dd class="mono">{% if t.exit_price %}${{ "{:,.2f}".format(t.exit_price) }}{% else %}—{% endif %}</dd>
+        <dt>Time</dt><dd class="mono">{{ t.entry_time }}</dd>
         {% if t.duration %}
-          <span class="label" style="margin-left:20px;">Duration</span><span class="mono small">{{ t.duration }}</span>
+        <dt>Duration</dt><dd class="mono">{{ t.duration }}</dd>
         {% endif %}
-        <span class="label" style="margin-left:20px;">Status</span>
-        <span class="badge-status badge-status-{{ t.status }}">{{ t.status }}</span>
-      </div>
+        <dt>Status</dt><dd><span class="badge-status badge-status-{{ t.status }}">{{ t.status }}</span></dd>
+      </dl>
 
       {% if t.reflection %}
       <details class="reflection-details">
@@ -110,21 +122,19 @@
 
 {% block scripts %}
 <script>
-  // Start all cycles collapsed
   document.querySelectorAll('.cycle-body').forEach(el => {
     el.style.display = 'none';
   });
 
   function toggleCycle(id) {
     const body = document.getElementById('body-' + id);
-    const btn  = document.querySelector('#' + id + ' .cycle-toggle');
+    const btn  = document.getElementById('btn-' + id);
     if (!body) return;
     const open = body.style.display !== 'none';
     body.style.display = open ? 'none' : 'block';
     if (btn) btn.textContent = open ? '▾' : '▴';
   }
 
-  // Expand first cycle by default
   const first = document.querySelector('.cycle-block');
   if (first) toggleCycle(first.id);
 </script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -162,6 +162,24 @@
         <div class="magi-lbl-vote">{{ mv.decision if mv else 'OFFLINE' }}</div>
       </div>
 
+      <!-- Mobile-only decision overlay (top-left empty area) -->
+      <div class="magi-lbl magi-lbl-mobile-decision">
+        <div class="magi-signal magi-signal-{{ (magi.consensus or 'hold') | lower }}">
+          {{ magi.consensus or 'HOLD' }}
+        </div>
+      </div>
+
+      <!-- Mobile-only status overlay (top-right empty area) -->
+      <div class="magi-lbl magi-lbl-mobile-status" id="magi-mobile-status">
+        <div class="magi-status-badge magi-running-badge">審議中</div>
+        {% if magi.rounds > 1 %}
+          <div class="magi-status-badge magi-deliberating magi-result-badge">再審議で決定</div>
+          <div class="magi-round-label magi-result-badge">第{{ magi.rounds - 1 }}回再審議</div>
+        {% else %}
+          <div class="magi-status-badge magi-status-resolved magi-result-badge">即時決定</div>
+        {% endif %}
+      </div>
+
     </div>
 
     <!-- Right: 決議 -->
@@ -233,6 +251,7 @@
   <div class="card">
     <div class="card-label">Recent Cycles</div>
     {% if recent_cycles %}
+      <div class="table-scroll">
       <table class="table">
         <thead>
           <tr>
@@ -255,6 +274,7 @@
           {% endfor %}
         </tbody>
       </table>
+      </div>
     {% else %}
       <div class="muted small">No cycles yet.</div>
     {% endif %}
@@ -264,6 +284,7 @@
   <div class="card">
     <div class="card-label">Recent Trades <a href="/trades" class="card-link">all →</a></div>
     {% if recent_trades %}
+      <div class="table-scroll">
       <table class="table">
         <thead>
           <tr>
@@ -296,6 +317,7 @@
           {% endfor %}
         </tbody>
       </table>
+      </div>
     {% else %}
       <div class="muted small">No trades yet.</div>
     {% endif %}
@@ -345,10 +367,14 @@
       const r = await fetch('/api/status');
       const data = await r.json();
 
-      // Toggle cycle-active on MAGI right panel
+      // Toggle cycle-active on MAGI right panel + mobile status overlay
       const magiRight = document.getElementById('magi-side-right');
       if (magiRight) {
         magiRight.classList.toggle('cycle-active', !!data.cycle_running);
+      }
+      const magiMobile = document.getElementById('magi-mobile-status');
+      if (magiMobile) {
+        magiMobile.classList.toggle('cycle-active', !!data.cycle_running);
       }
 
       // Update chart grid if new charts arrived

--- a/templates/trades.html
+++ b/templates/trades.html
@@ -5,6 +5,7 @@
 <div class="card">
   <div class="card-label">Trade History ({{ trades | length }} trades)</div>
   {% if trades %}
+    <div class="table-scroll">
     <table class="table table-full">
       <thead>
         <tr>
@@ -49,6 +50,7 @@
         {% endfor %}
       </tbody>
     </table>
+    </div>
   {% else %}
     <div class="muted" style="padding:2rem;text-align:center;">No trades yet.</div>
   {% endif %}


### PR DESCRIPTION
## Summary
- **Header**: スマホで2行レイアウト（1行目: ロゴ+カウントダウン、2行目: ナビ均等幅）
- **MAGI System**: スマホでサイドカラム非表示、SVG左上に議題（LONG/SHORT等）・右上に審議状態をPC版スタイルで表示
- **Tables**: `table-scroll` ラッパーで横スクロール対応、背景突き抜け解消
- **Cycles page**: ヘッダーを左右分割レイアウトに再設計、Trade詳細を `dl` グリッドに変更、Vote cardを整理

## Test plan
- [ ] スマホ幅（375px）でダッシュボード全ページを確認
- [ ] MAGI SVG左上に議題、右上に審議状態が表示される
- [ ] Tradesテーブルが横スクロールになる
- [ ] PC表示が変わっていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)