### PR TITLE
fix: escape HTML in cycles dashboard to prevent DOM nesting bug

### DIFF
--- a/templates/cycles.html
+++ b/templates/cycles.html
@@ -77,7 +77,7 @@
     {% if c.reasoning %}
     <div class="cycle-section">
       <div class="cycle-section-title">Consensus Reasoning</div>
-      <div class="cycle-reasoning prose">{{ c.reasoning | safe }}</div>
+      <div class="cycle-reasoning prose">{{ c.reasoning | e | replace('\n', '<br>') | safe }}</div>
     </div>
     {% endif %}
 
@@ -108,7 +108,7 @@
       {% if t.reflection %}
       <details class="reflection-details">
         <summary class="reflection-summary">Post-trade Reflection</summary>
-        <div class="reflection-body prose">{{ t.reflection | replace('\n', '<br>') | safe }}</div>
+        <div class="reflection-body prose">{{ t.reflection | e | replace('\n', '<br>') | safe }}</div>
       </details>
       {% endif %}
     </div>


### PR DESCRIPTION
LLM-generated reasoning text could contain unclosed HTML tags (e.g. <div>). Using `| safe` without escaping caused these tags to break the page layout, nesting subsequent cycle blocks inside earlier ones.

Apply `| e` (HTML escape) before `| replace('\n', '<br>')` on both c.reasoning and t.reflection to sanitize the output.

Fixes #16

https://claude.ai/code/session_018y2Jtbgd42nC1sBss8iKiU